### PR TITLE
Fixed typos in TypeHandlers.yml

### DIFF
--- a/_data/TypeHandlers.yml
+++ b/_data/TypeHandlers.yml
@@ -226,12 +226,12 @@
     - child-expand-height
   - name: childControlWidth
     type: bool
-    description: Whether or not to control the width it's chidlren
+    description: Whether or not to control the width it's children
     aliases:
     - child-control-width
   - name: childControlHeight
     type: bool
-    description: Whether or not to control the height it's chidlren
+    description: Whether or not to control the height it's children
     aliases:
     - child-control-height
 - type: LayoutElement


### PR DESCRIPTION
Stumbled upon those typos while reading through the documentation, but those are fixed now.