### PR TITLE
Added descriptions for stick scrolling & scrollbar for custom-list tags

### DIFF
--- a/_data/TypeHandlers.yml
+++ b/_data/TypeHandlers.yml
@@ -126,6 +126,16 @@
     description: Whether or not cells can be clicked or not
     aliases:
     - clickable-cells
+  - name: stickScrolling
+    type: bool
+    description: Whether or not to allow this table to scroll using the controller joystick
+    aliases:
+    - stick-scrolling
+  - name: showScrollbar
+    type: bool
+    description: Whether or not to show a scroll bar with buttons to scroll this table
+    aliases:
+    - show-scrollbar
 - type: CustomListTableData
   properties:
   - name: selectCell


### PR DESCRIPTION
I noticed that the BSMLSchema xsd marked the usage of the `stick-scrolling` and `show-scrollbar` attributes when used in a `<custom-list>` tag. This PR should fix that 🙂 